### PR TITLE
env setup with new build steps and updated CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,17 +36,9 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Move Assets
+    - name: Setup Dev Environment
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: .\scripts\CI\move_assets.bat
-
-    - name: Install EMSDK
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: .\external\emsdk\emsdk.bat install latest && .\external\emsdk\emsdk.bat activate latest
-
-    - name: Install VS Extensions
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: .\scripts\CI\install_extensions.bat
+      run: .\setup.bat
 
     - name: Build Solution
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -54,9 +46,9 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Move Build
+    - name: Copy Release
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: .\scripts\CI\move_build.bat
+      run: .\scripts\CI\copy_release.bat
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,6 +57,7 @@ jobs:
         path: Release
 
   deploy:
+    if: github.event_name == 'push'
     concurrency: ci-${{ github.ref }}
     needs: [build]
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -400,8 +400,14 @@ FodyWeavers.xsd
 # Emscripten
 Emscripten/
 
+# External cache
+external/cache
+
 # nodeJS
 external/nodejs
+
+# VSExt
+external/VSExt
 
 # assets
 src/assets

--- a/scripts/Build/copy_assets.bat
+++ b/scripts/Build/copy_assets.bat
@@ -5,7 +5,7 @@ set root="%~dp0..\..\"
 pushd %root%
 
 for /D %%G in ("assets") do (
-    move "%%G" "src\"
+    xcopy "%%G" "src\%%~nxG" /e /i /y /d
 )
 
 popd

--- a/scripts/Build/copy_index.bat
+++ b/scripts/Build/copy_index.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set root="%~dp0..\..\"
+pushd %root%
+
+if "%~1"=="" (
+    echo No destination directory specified. Exiting.
+    exit
+)
+
+if not exist "%~1\" (
+    echo The specified directory does not exist. Exiting.
+    exit
+)
+
+xcopy src\index.html "%~1\" /y /d
+
+popd
+endlocal

--- a/scripts/CI/copy_release.bat
+++ b/scripts/CI/copy_release.bat
@@ -5,7 +5,7 @@ set root="%~dp0..\..\"
 pushd %root%
 
 for /D %%G in ("bin\cs474-client\Emscripten\Release") do (
-    xcopy "%%G" ".\" /e /i /y
+    xcopy "%%G" ".\Release" /e /i /y
 )
 
 popd

--- a/scripts/CI/copy_release.bat
+++ b/scripts/CI/copy_release.bat
@@ -5,9 +5,8 @@ set root="%~dp0..\..\"
 pushd %root%
 
 for /D %%G in ("bin\cs474-client\Emscripten\Release") do (
-    move "%%G" "."
+    xcopy "%%G" ".\" /e /i /y
 )
 
-move src\index.html Release\
 popd
 endlocal

--- a/scripts/bootstrap_emcc.bat
+++ b/scripts/bootstrap_emcc.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set root="%~dp0..\"
+pushd %root%
+
+set emsdkboot=.\external\emsdk\emsdk.bat
+call %emsdkboot% install latest && %emsdkboot% activate latest
+
+popd
+endlocal

--- a/scripts/install_extension.bat
+++ b/scripts/install_extension.bat
@@ -1,24 +1,36 @@
 @echo off
 setlocal
 
-set root="%~dp0..\..\"
+set root="%~dp0..\"
 pushd %root%
 
 set vsix_installer="C:\Program Files (x86)\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe"
 
-rem make tool cache
+rem Create a marker file path for the installed extension
+set marker_file="external\VSExt\cache\Emscripten.Build.Definition.installed"
+
+rem Create tool cache directory if not exists
 if not exist external\VSExt\cache mkdir external\VSExt\cache
 
-rem download
+if exist %marker_file% (
+    echo The VSIX extension is already installed.
+    goto :end
+)
+
+if "%~1" == "--bypass" (
+    echo Bypassing installation and creating marker file.
+    echo Visual Studio Emscripten Extension installation bypassed on %date% %time% > %marker_file%
+    goto :end
+)
+
 if not exist external\VSExt\cache\Emscripten.Build.Definition.vsix (
     curl -L --show-error https://github.com/nokotan/VSExtForEmscripten/releases/download/v0.8.0/Emscripten.Build.Definition.vsix -o external\VSExt\cache\Emscripten.Build.Definition.vsix
 )
-if not exist external\VSExt\cache\Emscripten.ExtensionPack.vsix (
-    curl -L --show-error https://github.com/nokotan/VSExtForEmscripten/releases/download/v0.8.0/Emscripten.ExtensionPack.vsix -o external\VSExt\cache\Emscripten.ExtensionPack.vsix
-)
 
-rem install
 %vsix_installer% /q /a external\VSExt\cache\Emscripten.Build.Definition.vsix
 
+echo Installed on %date% %time% > %marker_file%
+
+:end
 popd
 endlocal

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set root="%~dp0"
+call .\scripts\install_node.bat
+call .\scripts\bootstrap_emcc.bat
+call .\scripts\install_extension.bat %1
+
+endlocal

--- a/src/cs474-client.vcxproj
+++ b/src/cs474-client.vcxproj
@@ -73,7 +73,8 @@
     <LibraryPath>
     </LibraryPath>
     <IncludePath>$(SolutionDir)include;$(IncludePath)</IncludePath>
-    <CustomBuildBeforeTargets>Build</CustomBuildBeforeTargets>
+    <CustomBuildBeforeTargets>
+    </CustomBuildBeforeTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
     <OutDir>$(SolutionDir)bin\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
@@ -81,7 +82,8 @@
     <LibraryPath>
     </LibraryPath>
     <IncludePath>$(SolutionDir)include;$(IncludePath)</IncludePath>
-    <CustomBuildBeforeTargets>Build</CustomBuildBeforeTargets>
+    <CustomBuildBeforeTargets>
+    </CustomBuildBeforeTargets>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Emscripten'">
     <Link>
@@ -99,9 +101,21 @@
       <PrecompiledHeaderFile>$(ProjectDir)\cs474.pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <CustomBuildStep>
-      <Command>$(SolutionDir)scripts\install_node.bat</Command>
-      <Outputs>node-v18.17.1-x64.msi</Outputs>
+      <Command>
+      </Command>
+      <Outputs>
+      </Outputs>
     </CustomBuildStep>
+    <PostBuildEvent>
+      <Command>$(SolutionDir)scripts\Build\copy_index.bat $(OutDir)</Command>
+      <Message>Copying Index.html to $(OutDir) ...</Message>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)scripts\Build\copy_assets.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Copying Build Assets to $(ProjectDir) ...</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
     <Link>
@@ -119,9 +133,21 @@
       <PrecompiledHeaderFile>$(ProjectDir)\cs474.pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <CustomBuildStep>
-      <Command>$(SolutionDir)scripts\install_node.bat</Command>
-      <Outputs>node-v18.17.1-x64.msi</Outputs>
+      <Command>
+      </Command>
+      <Outputs>
+      </Outputs>
     </CustomBuildStep>
+    <PostBuildEvent>
+      <Command>$(SolutionDir)scripts\Build\copy_index.bat $(OutDir)</Command>
+      <Message>Copying Index.html to $(OutDir) ...</Message>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)scripts\Build\copy_assets.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Copying Build Assets to $(ProjectDir) ...</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
this adds a `setup.bat` to the top level directory which:

- bootstraps emscripten (install latest and activate latest)
- installs vs extension for emscripten (this can take 4ever, it's necessary for guthub actions, but since it's unnecessary for us, we can use the --bypass arg to forgo it)

So on a clean recursive pull we can just do:
```
.\setup.bat --bypass
```
Additionally, all the asset directory copying and index.html copying occurs as part of a Visual Studio build step, so therefore is now automatic. New assets can just be added to the assets directory in the top level and will be moved into src and embedded on build automatically