### PR TITLE
added solution-item filters & moved imgui to a lib

### DIFF
--- a/cs474.sln
+++ b/cs474.sln
@@ -3,9 +3,38 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D50D950B-C19C-1ED5-6ABB-32D056292F7B}"
+	ProjectSection(SolutionItems) = preProject
+		setup.bat = setup.bat
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{352CD55D-21E4-16AB-8AEB-EF0676C2B19B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "external", "external", "{1D4A25CE-E895-42B0-82F5-FC40AE01B9B6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{B1D82354-E3B8-4F29-BA48-E05166777FA6}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\bootstrap_emcc.bat = scripts\bootstrap_emcc.bat
+		scripts\install_extension.bat = scripts\install_extension.bat
+		scripts\install_node.bat = scripts\install_node.bat
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{D48DD573-3188-42DB-9A64-C02A18555758}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\CI\copy_release.bat = scripts\CI\copy_release.bat
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{70B552D7-6AEF-4FA2-BAEB-DEE0AC300264}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\Build\copy_assets.bat = scripts\Build\copy_assets.bat
+		scripts\Build\copy_index.bat = scripts\Build\copy_index.bat
+	EndProjectSection
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cs474-client", "src\cs474-client.vcxproj", "{14CCC210-1667-4DE1-A6C6-F168A6AC8C52}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cs474", "include\cs474.vcxproj", "{BE4F55EF-BD86-4733-AA49-37D31497AA19}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "imgui", "external\imgui.vcxproj", "{76095DD0-00A6-4336-9924-125A263E80AC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,9 +60,25 @@ Global
 		{BE4F55EF-BD86-4733-AA49-37D31497AA19}.Release|Emscripten.Build.0 = Release|Emscripten
 		{BE4F55EF-BD86-4733-AA49-37D31497AA19}.Release|x64.ActiveCfg = Release|Emscripten
 		{BE4F55EF-BD86-4733-AA49-37D31497AA19}.Release|x64.Build.0 = Release|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Debug|Emscripten.ActiveCfg = Debug|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Debug|Emscripten.Build.0 = Debug|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Debug|x64.ActiveCfg = Debug|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Debug|x64.Build.0 = Debug|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Release|Emscripten.ActiveCfg = Release|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Release|Emscripten.Build.0 = Release|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Release|x64.ActiveCfg = Release|Emscripten
+		{76095DD0-00A6-4336-9924-125A263E80AC}.Release|x64.Build.0 = Release|Emscripten
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B1D82354-E3B8-4F29-BA48-E05166777FA6} = {D50D950B-C19C-1ED5-6ABB-32D056292F7B}
+		{D48DD573-3188-42DB-9A64-C02A18555758} = {B1D82354-E3B8-4F29-BA48-E05166777FA6}
+		{70B552D7-6AEF-4FA2-BAEB-DEE0AC300264} = {B1D82354-E3B8-4F29-BA48-E05166777FA6}
+		{14CCC210-1667-4DE1-A6C6-F168A6AC8C52} = {352CD55D-21E4-16AB-8AEB-EF0676C2B19B}
+		{BE4F55EF-BD86-4733-AA49-37D31497AA19} = {352CD55D-21E4-16AB-8AEB-EF0676C2B19B}
+		{76095DD0-00A6-4336-9924-125A263E80AC} = {1D4A25CE-E895-42B0-82F5-FC40AE01B9B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0880232E-B5A9-4ACE-8430-80A7D0614255}

--- a/external/imgui.vcxproj
+++ b/external/imgui.vcxproj
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Emscripten">
+      <Configuration>Debug</Configuration>
+      <Platform>Emscripten</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Emscripten">
+      <Configuration>Release</Configuration>
+      <Platform>Emscripten</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="imgui\backends\imgui_impl_glfw.cpp" />
+    <ClCompile Include="imgui\backends\imgui_impl_opengl3.cpp" />
+    <ClCompile Include="imgui\imgui.cpp" />
+    <ClCompile Include="imgui\imgui_demo.cpp" />
+    <ClCompile Include="imgui\imgui_draw.cpp" />
+    <ClCompile Include="imgui\imgui_tables.cpp" />
+    <ClCompile Include="imgui\imgui_widgets.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{76095dd0-00a6-4336-9924-125a263e80ac}</ProjectGuid>
+    <RootNamespace>imgui</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Emscripten'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>emcc</PlatformToolset>
+    <EmscriptenDir>$(SolutionDir)\external\emsdk\upstream\emscripten</EmscriptenDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>emcc</PlatformToolset>
+    <EmscriptenDir>$(SolutionDir)\external\emsdk\upstream\emscripten</EmscriptenDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Emscripten'">
+    <OutDir>$(SolutionDir)bin\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)bin-int\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
+    <OutDir>$(SolutionDir)bin\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)bin-int\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>lib$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Emscripten'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/cs474-client.vcxproj
+++ b/src/cs474-client.vcxproj
@@ -11,13 +11,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\external\imgui\backends\imgui_impl_glfw.cpp" />
-    <ClCompile Include="..\external\imgui\backends\imgui_impl_opengl3.cpp" />
-    <ClCompile Include="..\external\imgui\imgui.cpp" />
-    <ClCompile Include="..\external\imgui\imgui_demo.cpp" />
-    <ClCompile Include="..\external\imgui\imgui_draw.cpp" />
-    <ClCompile Include="..\external\imgui\imgui_tables.cpp" />
-    <ClCompile Include="..\external\imgui\imgui_widgets.cpp" />
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="cs474-client.cpp" />
     <ClCompile Include="cs474.pch.cpp" />
@@ -27,6 +20,9 @@
     <ClCompile Include="Layer\Base.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\external\imgui.vcxproj">
+      <Project>{76095dd0-00a6-4336-9924-125a263e80ac}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\include\cs474.vcxproj">
       <Project>{be4f55ef-bd86-4733-aa49-37d31497aa19}</Project>
     </ProjectReference>
@@ -44,6 +40,9 @@
     <ClInclude Include="cs474.pch.h" />
     <ClInclude Include="Utils\imgui_helpers.hpp" />
     <ClInclude Include="Utils\io.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="index.html" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
@@ -87,8 +86,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Emscripten'">
     <Link>
-      <AdditionalDependencies>cs474</AdditionalDependencies>
-      <AdditionalLinkDirectories>$(SolutionDir)bin\cs474\$(Platform)\$(Configuration)\</AdditionalLinkDirectories>
+      <AdditionalDependencies>cs474; imgui</AdditionalDependencies>
+      <AdditionalLinkDirectories>$(SolutionDir)bin\cs474\$(Platform)\$(Configuration)\; $(SolutionDir)bin\imgui\$(Platform)\$(Configuration)\</AdditionalLinkDirectories>
       <AdditionalOptions>-s USE_WEBGL2=1 -s USE_GLFW=3 -s FULL_ES3=1 -s WASM=1  -s ALLOW_MEMORY_GROWTH --preload-file assets/ %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ProjectReference>
@@ -119,8 +118,8 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Emscripten'">
     <Link>
-      <AdditionalDependencies>cs474</AdditionalDependencies>
-      <AdditionalLinkDirectories>$(SolutionDir)bin\cs474\$(Platform)\$(Configuration)\</AdditionalLinkDirectories>
+      <AdditionalDependencies>cs474; imgui</AdditionalDependencies>
+      <AdditionalLinkDirectories>$(SolutionDir)bin\cs474\$(Platform)\$(Configuration)\; $(SolutionDir)bin\imgui\$(Platform)\$(Configuration)\</AdditionalLinkDirectories>
       <AdditionalOptions>-s USE_WEBGL2=1 -s USE_GLFW=3 -s FULL_ES3=1 -s WASM=1  -s ALLOW_MEMORY_GROWTH --preload-file assets/ %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ProjectReference>


### PR DESCRIPTION
Added solution-item filters to better organize our solution explorer:
![image](https://github.com/Stehfyn/cs474/assets/67705843/e1378ba9-d7f3-4ae3-8c5c-d6ba65042659)

build and env scripts are now accessible without leaving the ide and imgui now builds as its own static lib. probably will do the same for new dependencies for the windows native target (glfw, glew, etc)